### PR TITLE
Evals the return of CFBundleShortVersionString

### DIFF
--- a/scripts/build-pre-actions.sh
+++ b/scripts/build-pre-actions.sh
@@ -3,7 +3,8 @@
 if [ "$CONFIGURATION" == "Release" ] ; then
 
 PLISTPATH="$SRCROOT/$INFOPLIST_FILE"
-VERSIONNUM=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$PLISTPATH")
+PLISTVERSIONNUM=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$PLISTPATH")
+VERSIONNUM="$(eval echo "$PLISTVERSIONNUM")"
 FIRSTCOMPONENT=`echo $VERSIONNUM | awk -F "." '{print $1}'`
 SECONDCOMPONENT=`echo $VERSIONNUM | awk -F "." '{print $2}'`
 THIRDCOMPONENT=`echo $VERSIONNUM | awk -F "." '{print $3}'`


### PR DESCRIPTION
If the value in CFBundleShortVersionString is a link to another variable (like “$(MARKETING_VERSION)”), the parsing of the variable was when seting the BUILDNUMBER.

In that case, FIRSTCOMPONENT was set to ‘$(MARKETING_VERSION)’, SECONDCOMPONENT was set to ‘’ and THIRDCOMPONENT was set to ‘’ (and thus reset to 0).  This lead to having a BUILDNUMBER set to $(MARKETING_VERSION)..0.$(DATE).

With two dots following each other, upload of the build would be denied by Apple.